### PR TITLE
Update inventory.yaml

### DIFF
--- a/k8s/inventory.yaml
+++ b/k8s/inventory.yaml
@@ -48,6 +48,7 @@ metadata:
     app: catalog
   name: catalog-lightblue-service
 spec:
+  path: "/catalog"
   port:
     targetPort: 8081
   to:


### PR DESCRIPTION
This addresses an issue in inventory.yaml that allows any path to be called. This will change the file to restrict the route to only allow /catalog.